### PR TITLE
revamp looper plugin to accomodate multiple genomes

### DIFF
--- a/refgenconf/populator.py
+++ b/refgenconf/populator.py
@@ -84,7 +84,9 @@ def looper_refgenie_populate(namespaces):
                 try:
                     paths_dict[g][k] = v[tag]
                 except KeyError:
-                    _LOGGER.warn(f"Can't find tag '{tag}' for asset '{g}/{k}', as specified in your project config. Using default.")
+                    _LOGGER.warn(
+                        f"Can't find tag '{tag}' for asset '{g}/{k}', as specified in your project config. Using default."
+                    )
                     paths_dict[g][k] = v["default"]
 
         for po in namespaces["project"]["refgenie"]["path_overrides"]:

--- a/refgenconf/populator.py
+++ b/refgenconf/populator.py
@@ -89,13 +89,14 @@ def looper_refgenie_populate(namespaces):
                     )
                     paths_dict[g][k] = v["default"]
 
-        for po in namespaces["project"]["refgenie"]["path_overrides"]:
-            rp = prp(po["registry_path"])
-            _LOGGER.debug(f"Overriding {po['registry_path']} with {po['value']}.")
-            if not rp["subitem"]:
-                rp["subitem"] = rp["item"]
-            _LOGGER.debug(rp)
-            paths_dict[rp["namespace"]][rp["item"]][rp["subitem"]] = po["value"]
+        if "refgenie" in namespaces["project"]:
+            for po in namespaces["project"]["refgenie"]["path_overrides"]:
+                rp = prp(po["registry_path"])
+                _LOGGER.debug(f"Overriding {po['registry_path']} with {po['value']}.")
+                if not rp["subitem"]:
+                    rp["subitem"] = rp["item"]
+                _LOGGER.debug(rp)
+                paths_dict[rp["namespace"]][rp["item"]][rp["subitem"]] = po["value"]
 
         # print(paths_dict)
         # Provide these values under the 'refgenie' namespace


### PR DESCRIPTION
Here's what I came up with. This makes the plugin more general.

Use with:

```
pre_submit:
  python_functions:
  - refgenconf.looper_refgenie_populate
var_templates:
  refgenie_config: "$REFGENIE"
command_template: >
  python pipeline.py 
  --index {refgenie[sample.genome].bowtie2_index.dir}
  --fasta-file {refgenie[sample.genome].fasta.fasta}
  --sample-name {sample.sample_name}
  --anno-name {refgenie[sample.genome].bwa_index.bwa_index}
  --custom-config {sample.custom_config_path}
```

So, now you can use `refgenie[GENOME]` to get at different genomes.

The way to configure the plugin in the PEP is now like this: 

```
refgenie:
  tag_overrides:
    t7:
      bowtie2_index: "alternative_tag"
  path_overrides:
    - registry_path: "hg19/bowtie2_index"
      value: "test.xyz"
    - registry_path: "hg38/fasta.chrom_sizes"
      value: "refgenie://hg38_primary/fasta.chrom_sizes"
```

- `tag_overrides` allows you to specify a tag for a particular genome and asset
- `path_overrides` allows you to override a specific seek key with a path. You can use either direct paths, or refgenie registry paths.

